### PR TITLE
Allow additional parseDT return codes

### DIFF
--- a/snoozybot/discord_bot/commands/reminder.py
+++ b/snoozybot/discord_bot/commands/reminder.py
@@ -33,7 +33,7 @@ async def reminder_group(ctx: lightbulb.SlashContext) -> None:
 @lightbulb.implements(lightbulb.SlashSubCommand)
 async def reminder_set(ctx: lightbulb.SlashContext) -> None:
     time, parse_status = _calendar.parseDT(ctx.options.time)
-    if time is None:
+    if time is None or parse_status == 0:
         raise UserError(f'"{ctx.options.time!r} is not a valid relative time. '
                         f'Try something like "3 minutes" or "2 days"')
     if time <= datetime.now():

--- a/snoozybot/discord_bot/commands/reminder.py
+++ b/snoozybot/discord_bot/commands/reminder.py
@@ -33,7 +33,7 @@ async def reminder_group(ctx: lightbulb.SlashContext) -> None:
 @lightbulb.implements(lightbulb.SlashSubCommand)
 async def reminder_set(ctx: lightbulb.SlashContext) -> None:
     time, parse_status = _calendar.parseDT(ctx.options.time)
-    if parse_status == 0:
+    if time is None:
         raise UserError(f'"{ctx.options.time!r} is not a valid relative time. '
                         f'Try something like "3 minutes" or "2 days"')
     if time <= datetime.now():

--- a/snoozybot/discord_bot/commands/reminder.py
+++ b/snoozybot/discord_bot/commands/reminder.py
@@ -33,7 +33,7 @@ async def reminder_group(ctx: lightbulb.SlashContext) -> None:
 @lightbulb.implements(lightbulb.SlashSubCommand)
 async def reminder_set(ctx: lightbulb.SlashContext) -> None:
     time, parse_status = _calendar.parseDT(ctx.options.time)
-    if parse_status != 2:
+    if parse_status == 0:
         raise UserError(f'"{ctx.options.time!r} is not a valid relative time. '
                         f'Try something like "3 minutes" or "2 days"')
     if time <= datetime.now():


### PR DESCRIPTION
This should hopefully resolve a bug where users that enter a time of "`n` days" would receive an error.
When a user enters something like "2 days" [Calendar.parseDT](https://bear.im/code/parsedatetime/docs/index.html) most likely returns a value of 1 or 3, not 2. However, both of those are still `struct_time` objects, so the `time` method should work as expected in either case. If that's not the case, then we'll have to change how we parse different `struct_time` objects returned. I unfortunately am unable to test this code.